### PR TITLE
only get extension data if it actually exists

### DIFF
--- a/Wave.php
+++ b/Wave.php
@@ -285,7 +285,7 @@ class Wave
             $extensionSize = current(unpack('v', fread($fh, 2)));
             $chunk->setExtensionSize($extensionSize);
         }
-        if ($size >= 20) {
+        if ($size >= 20 && $extensionSize==22) {
             $extensionData = fread($fh, $extensionSize);
             $chunk->setExtensionData($extensionData);
         }


### PR DESCRIPTION
This fixes an issue I was having where it would throw an exception in Laravel if there was no extension data in the wav fmt chunk. Therefore this just checks if extension/cb size is 22 (i.e. not 0 - see http://www-mmsp.ece.mcgill.ca/documents/audioformats/wave/wave.html) before grabbing any extension data.
